### PR TITLE
Fix case of "master" branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Orbs are reusable [commands](https://circleci.com/docs/2.0/reusing-config/#autho
 
 ## What is in this kit?
 
-In this Orb-Starter-Kit you will find an automated setup to create a development pipeline to build your orb automatically. Once setup is complete you will have a functioning hello-world orb that is automatically build and released on each commit. Commits to the "Master" branch will trigger production Orb releases and other branches will create development versions of your Orb for testing.
+In this Orb-Starter-Kit you will find an automated setup to create a development pipeline to build your orb automatically. Once setup is complete you will have a functioning hello-world orb that is automatically build and released on each commit. Commits to the `master` branch will trigger production Orb releases and other branches will create development versions of your Orb for testing.
 
 ### Prerequisites
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

As a new reviewer of the README, it is easier for me to see smaller typos.

### Description

The "Master" branch as stated may indicate to neophyte users that the typical `master` branch has an upper case letter. Also, to help indicate that this is a branch name, the double quotes were moved to back graves as used in GitHub Markdown.