### PR TITLE
Checking for existing circleci executable

### DIFF
--- a/_init/_installCLI.sh
+++ b/_init/_installCLI.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 _installCLI() {
-    curl -fLSs https://circle.ci/cli | sudo bash && circleci setup
-    sleep 1
-    echo
-    echo "setting token internally"
-    CCI_TOKEN=$(awk '/token:/ {print $2}' "$HOME/.circleci/cli.yml")
+    if [ -x "$(command -v circleci)" ]; then
+        echo "circleci cli already installed"
+        circleci setup
+        echo "setting token internally"
+        CLI_FILE_PATH=$(circleci diagnostic | grep "Config found:" | awk '{print $3}')        
+    else
+        echo "circleci cli not installed"
+        curl -fLSs https://circle.ci/cli | sudo bash && circleci setup
+        sleep 1
+        echo
+        echo "setting token internally"
+        CLI_FILE_PATH="$HOME/.circleci/cli.yml"
+    fi
+
+    echo $CLI_FILE_PATH
+    CCI_TOKEN=$(awk '/token:/ {print $2}' "$CLI_FILE_PATH")
 }
+
+_installCLI

--- a/_init/_installCLI.sh
+++ b/_init/_installCLI.sh
@@ -17,5 +17,3 @@ _installCLI() {
     echo $CLI_FILE_PATH
     CCI_TOKEN=$(awk '/token:/ {print $2}' "$CLI_FILE_PATH")
 }
-
-_installCLI


### PR DESCRIPTION
Using the `cli.yml` path when grabbing the token from the diagnostic output. Resolves #16