### PR TITLE
Fix shellcheck warning of SC2086

### DIFF
--- a/_init/_installCLI.sh
+++ b/_init/_installCLI.sh
@@ -14,6 +14,6 @@ _installCLI() {
         CLI_FILE_PATH="$HOME/.circleci/cli.yml"
     fi
 
-    echo $CLI_FILE_PATH
+    echo "$CLI_FILE_PATH"
     CCI_TOKEN=$(awk '/token:/ {print $2}' "$CLI_FILE_PATH")
 }


### PR DESCRIPTION
This fixes the following warning from shellcheck.

```
In ./_init/_installCLI.sh line 17:
    echo $CLI_FILE_PATH
         ^------------^ SC2086: Double quote to prevent globbing and word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```